### PR TITLE
Fix lost track bug and expose parameters

### DIFF
--- a/src/byte_tracker.rs
+++ b/src/byte_tracker.rs
@@ -15,6 +15,17 @@ pub struct ByteTracker {
     track_thresh: f32,
     high_thresh: f32,
     match_thresh: f32,
+    low_conf_match_thresh: f32,
+    kalman_std_weight_pos: f32,
+    kalman_std_weight_vel: f32,
+    kalman_std_weight_position_meas: f32,
+    kalman_std_weight_position_mot: f32,
+    kalman_std_weight_velocity_mot: f32,
+    kalman_std_aspect_ratio_init: f32,
+    kalman_std_d_aspect_ratio_init: f32,
+    kalman_std_aspect_ratio_mot: f32,
+    kalman_std_d_aspect_ratio_mot: f32,
+    kalman_std_aspect_ratio_meas: f32,
     max_time_lost: usize,
 
     frame_id: usize,
@@ -32,11 +43,33 @@ impl ByteTracker {
         track_thresh: f32,
         high_thresh: f32,
         match_thresh: f32,
+        low_conf_match_thresh: f32,
+        kalman_std_weight_pos: f32,
+        kalman_std_weight_vel: f32,
+        kalman_std_weight_position_meas: f32,
+        kalman_std_weight_position_mot: f32,
+        kalman_std_weight_velocity_mot: f32,
+        kalman_std_aspect_ratio_init: f32,
+        kalman_std_d_aspect_ratio_init: f32,
+        kalman_std_aspect_ratio_mot: f32,
+        kalman_std_d_aspect_ratio_mot: f32,
+        kalman_std_aspect_ratio_meas: f32,
     ) -> Self {
         Self {
             track_thresh,
             high_thresh,
             match_thresh,
+            low_conf_match_thresh: f32,
+            kalman_std_weight_pos: f32,
+            kalman_std_weight_vel: f32,
+            kalman_std_weight_position_meas: f32,
+            kalman_std_weight_position_mot: f32,
+            kalman_std_weight_velocity_mot: f32,
+            kalman_std_aspect_ratio_init: f32,
+            kalman_std_d_aspect_ratio_init: f32,
+            kalman_std_aspect_ratio_mot: f32,
+            kalman_std_d_aspect_ratio_mot: f32,
+            kalman_std_aspect_ratio_meas: f32,
             max_time_lost: (track_buffer as f32 * frame_rate as f32 / 30.0)
                 as usize,
 
@@ -66,6 +99,16 @@ impl ByteTracker {
                 obj.get_detection_id(),
                 obj.get_rect(),
                 obj.get_prob(),
+                self.kalman_std_weight_pos,
+                self.kalman_std_weight_vel,
+                self.kalman_std_weight_position_meas,
+                self.kalman_std_weight_position_mot,
+                self.kalman_std_weight_velocity_mot,
+                self.kalman_std_aspect_ratio_init,
+                self.kalman_std_d_aspect_ratio_init,
+                self.kalman_std_aspect_ratio_mot,
+                self.kalman_std_d_aspect_ratio_mot,
+                self.kalman_std_aspect_ratio_meas,
             );
             if obj.get_prob() >= self.track_thresh {
                 det_stracks.push(strack);
@@ -86,12 +129,17 @@ impl ByteTracker {
             }
         }
 
-        let mut strack_pool =
-            Self::joint_stracks(&active_stracks, &self.lost_stracks);
         // Predict the current location with KF
-        for strack in strack_pool.iter_mut() {
-            strack.predict();
+        for track in active_stracks.iter_mut() {
+            track.predict();
         }
+        let mut original_lost_stracks = Vec::new();
+        for track in self.lost_stracks.iter() {
+            let mut cloned = track.clone();
+            cloned.predict();
+            original_lost_stracks.push(cloned);
+        }
+        let mut strack_pool = Self::joint_stracks(&active_stracks, &original_lost_stracks);
 
         /* ------------------ Step 2: First association with IoU ------------------------- */
         let mut current_tracked_stracks = Vec::new();
@@ -123,7 +171,7 @@ impl ByteTracker {
                     track.re_activate(
                         det,
                         self.frame_id,
-                        -1, /* defualt value */
+                        -1, /* default value */
                     );
                     refined_stracks.push(track.clone());
                 }
@@ -156,7 +204,7 @@ impl ByteTracker {
                     &iou_distance,
                     remain_tracked_stracks.len(),
                     det_low_stracks.len(),
-                    0.5,
+                    self.low_conf_match_thresh,
                 )?;
 
             for (idx, sol) in matches_idx {
@@ -172,7 +220,7 @@ impl ByteTracker {
                     track.re_activate(
                         det,
                         self.frame_id,
-                        -1, /* defulat value */
+                        -1, /* default value */
                     );
                     refined_stracks.push(track.clone());
                 }
@@ -240,7 +288,7 @@ impl ByteTracker {
 
         // calculate the number of removed objects
         let subtrack_stracks =
-            Self::sub_stracks(&self.lost_stracks, &self.tracked_stracks);
+            Self::sub_stracks(&original_lost_stracks, &self.tracked_stracks);
         let joint_stracks =
             Self::joint_stracks(&subtrack_stracks, &current_lost_stracks);
         self.lost_stracks =

--- a/src/kalman_filter.rs
+++ b/src/kalman_filter.rs
@@ -21,6 +21,14 @@ pub(crate) type StateHCov = SMatrix<f32, 4, 4>;
 pub(crate) struct KalmanFilter {
     std_weight_position: f32,
     std_weight_velocity: f32,
+    std_weight_position_meas: f32,
+    std_weight_position_mot: f32,
+    std_weight_velocity_mot: f32,
+    std_aspect_ratio_init: f32,
+    std_d_aspect_ratio_init: f32,
+    std_aspect_ratio_mot: f32,
+    std_d_aspect_ratio_mot: f32,
+    std_aspect_ratio_meas: f32,
     motion_mat: SMatrix<f32, 8, 8>, // 8x8
     update_mat: SMatrix<f32, 4, 8>, // 4x8
 }
@@ -29,6 +37,14 @@ impl KalmanFilter {
     pub(crate) fn new(
         std_weight_position: f32,
         std_weight_velocity: f32,
+        std_weight_position_meas: f32,
+        std_weight_position_mot: f32,
+        std_weight_velocity_mot: f32,
+        std_aspect_ratio_init: f32,
+        std_d_aspect_ratio_init: f32,
+        std_aspect_ratio_mot: f32,
+        std_d_aspect_ratio_mot: f32,
+        std_aspect_ratio_meas: f32,
     ) -> Self {
         let ndim = 4;
         let dt = 1.0;
@@ -52,6 +68,14 @@ impl KalmanFilter {
         return Self {
             std_weight_position,
             std_weight_velocity,
+            std_weight_position_meas,
+            std_weight_position_mot,
+            std_weight_velocity_mot,
+            std_aspect_ratio_init,
+            std_d_aspect_ratio_init,
+            std_aspect_ratio_mot,
+            std_d_aspect_ratio_mot,
+            std_aspect_ratio_meas,
             motion_mat,
             update_mat,
         };
@@ -72,11 +96,11 @@ impl KalmanFilter {
         let mesure_val = measurement[(0, 3)];
         std[0] = 2.0 * self.std_weight_position * mesure_val;
         std[1] = 2.0 * self.std_weight_position * mesure_val;
-        std[2] = 1e-2;
+        std[2] = self.std_aspect_ratio_init;
         std[3] = 2.0 * self.std_weight_position * mesure_val;
         std[4] = 10.0 * self.std_weight_velocity * mesure_val;
         std[5] = 10.0 * self.std_weight_velocity * mesure_val;
-        std[6] = 1e-5;
+        std[6] = self.std_d_aspect_ratio_init;
         std[7] = 10.0 * self.std_weight_velocity * mesure_val;
 
         let tmp = std.component_mul(&std);
@@ -90,14 +114,14 @@ impl KalmanFilter {
         covariance: &mut StateCov,
     ) {
         let mut std = SMatrix::<f32, 1, 8>::zeros();
-        std[0] = self.std_weight_position * mean[(0, 3)];
-        std[1] = self.std_weight_position * mean[(0, 3)];
-        std[2] = 1e-2;
-        std[3] = self.std_weight_position * mean[(0, 3)];
-        std[4] = self.std_weight_velocity * mean[(0, 3)];
-        std[5] = self.std_weight_velocity * mean[(0, 3)];
-        std[6] = 1e-5;
-        std[7] = self.std_weight_velocity * mean[(0, 3)];
+        std[0] = self.std_weight_position_mot * mean[(0, 3)];
+        std[1] = self.std_weight_position_mot * mean[(0, 3)];
+        std[2] = self.std_aspect_ratio_mot;
+        std[3] = self.std_weight_position_mot * mean[(0, 3)];
+        std[4] = self.std_weight_velocity_mot * mean[(0, 3)];
+        std[5] = self.std_weight_velocity_mot * mean[(0, 3)];
+        std[6] = self.std_d_aspect_ratio_mot;
+        std[7] = self.std_weight_velocity_mot * mean[(0, 3)];
 
         let tmp = std.component_mul(&std);
         let motion_cov = SMatrix::<f32, 8, 8>::from_diagonal(&tmp.transpose());
@@ -143,10 +167,10 @@ impl KalmanFilter {
         covariance: &StateCov,           // 8x8
     ) {
         let std = SMatrix::<f32, 1, 4>::from_iterator([
-            self.std_weight_position * mean[(0, 3)],
-            self.std_weight_position * mean[(0, 3)],
-            1e-1,
-            self.std_weight_position * mean[(0, 3)],
+            self.std_weight_position_meas * mean[(0, 3)],
+            self.std_weight_position_meas * mean[(0, 3)],
+            self.std_aspect_ratio_meas,
+            self.std_weight_position_meas * mean[(0, 3)],
         ]);
 
         // update_mat: 4x8, mean: 1x8

--- a/src/strack.rs
+++ b/src/strack.rs
@@ -46,8 +46,33 @@ pub(crate) struct STrack {
 }
 
 impl STrack {
-    pub(crate) fn new(detection_id: i64, rect: Rect<f32>, score: f32) -> Self {
-        let kalman_filter = KalmanFilter::new(1.0 / 20., 1.0 / 160.);
+    pub(crate) fn new(
+        detection_id: i64, 
+        rect: Rect<f32>, 
+        score: f32,
+        std_weight_pos: f32, 
+        std_weight_vel: f32,
+        std_weight_position_meas: f32,
+        std_weight_position_mot: f32,
+        std_weight_velocity_mot: f32,
+        std_aspect_ratio_init: f32,
+        std_d_aspect_ratio_init: f32,
+        std_aspect_ratio_mot: f32,
+        std_d_aspect_ratio_mot: f32,
+        std_aspect_ratio_meas: f32,
+    ) -> Self {
+        let kalman_filter = KalmanFilter::new(
+            std_weight_pos,
+            std_weight_vel,
+            std_weight_position_meas,
+            std_weight_position_mot, 
+            std_weight_velocity_mot,
+            std_aspect_ratio_init,
+            std_d_aspect_ratio_init,
+            std_aspect_ratio_mot,
+            std_d_aspect_ratio_mot,
+            std_aspect_ratio_meas,
+        );
         let mean = StateMean::zeros();
         let covariance = StateCov::zeros();
         Self {
@@ -69,7 +94,7 @@ impl STrack {
     // This function is used in the test_joint_strack function in src/test_byte_tracker.rs
     #[cfg(test)]
     pub(crate) fn dummy_strack(track_id: usize) -> Self {
-        let kalman_filter = KalmanFilter::new(1.0 / 20., 1.0 / 160.);
+        let kalman_filter = KalmanFilter::new(1.0 / 20., 1.0 / 160., 1.0 / 20., 1.0 / 20., 1.0 / 160., 1e-2, 1e-5, 1e-2, 1e-5, 1e-1);
         let mean = StateMean::zeros();
         let covariance = StateCov::zeros();
         Self {


### PR DESCRIPTION
- Fixed issue where lost tracks in update step where not calling kalman.predict (ie staying static)
- Expose bytetrack and kalman parameters for tuning

Before: lost tracks are static despite velocity arrows, kalman predict is not being propagated through the bytretrack update call
https://github.com/user-attachments/assets/48026783-096a-48f1-abf9-fe3add2aa3ce

After: fixed, lost tracks move based on kalman prediction frame to frame
https://github.com/user-attachments/assets/c8934fd4-7525-47f5-89cf-e1fcd7fac118